### PR TITLE
Fix chat PubSub configuration

### DIFF
--- a/src/aws/pubsub.js
+++ b/src/aws/pubsub.js
@@ -1,5 +1,5 @@
 import { Amplify } from 'aws-amplify';
-import { Auth } from '@aws-amplify/auth';
+import { fetchAuthSession } from '@aws-amplify/auth';
 let lastToken = null;
 
 export default async function ensurePubSub(token) {
@@ -7,7 +7,7 @@ export default async function ensurePubSub(token) {
   console.log('Configuring Amplify PubSub');
   try {
     // Wait until Cognito has exchanged the Google token for temporary AWS creds
-    await Auth.currentCredentials();
+    await fetchAuthSession();
   } catch {
     // Swallow errors to avoid blocking configuration
   }

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -53,7 +53,13 @@ export default function useChat(groupId) {
       ).subscribe({
         next: (data) => {
           console.log('Received message', data);
-          setMessages((m) => [...m, data.value.data.sendMessage]);
+          const msg = data.value.data.sendMessage;
+          setMessages((m) => {
+            if (m.some((ex) => ex.ts === msg.ts && ex.userId === msg.userId)) {
+              return m;
+            }
+            return [...m, msg];
+          });
         },
         error: (err) => {
           console.error('Subscription error', err);


### PR DESCRIPTION
## Summary
- configure Amplify PubSub using `fetchAuthSession`
- avoid duplicate chat messages by checking timestamp/user

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ac5283658832cb32cdd66a8613e0d